### PR TITLE
Fix evaluation

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ from the `nix` flake:
     nixosConfigurations.my-machine = nixpkgs.lib.nixosSystem {
       modules =
         [ dwarffs.nixosModules.dwarffs
-          { nixpkgs.overlays = [ nix.overlay ]; }
+          { nixpkgs.overlays = [ nix.overlays.default ]; }
           # ... other configuration ...
         ];
     };

--- a/flake.nix
+++ b/flake.nix
@@ -55,7 +55,7 @@
             nodes = {
               client = { ... }: {
                 imports = [ self.nixosModules.dwarffs ];
-                nixpkgs.overlays = [ nix.overlay ];
+                nixpkgs.overlays = [ nix.overlays.default ];
               };
             };
 


### PR DESCRIPTION
`nix.overlay` was only partially removed in #22, which thus accidentally broke
evaluation of the flake.
See also: https://hydra.nixos.org/eval/1768881#tabs-errors