### PR TITLE
NixOS: use pinned dependencies

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -76,14 +76,24 @@
           };
       });
 
-      nixosModules.dwarffs =
-        { pkgs, ... }:
-        {
-          nixpkgs.overlays = [ self.overlay ];
+      nixosModules.dwarffs = { config, lib, pkgs, ... }:
+      let cfg = config.services.dwarffs;
+      in
+      {
+        options.services.dwarffs = {
+          package = lib.mkOption {
+            type = lib.types.package;
+            description = ''
+              Which dwarffs package to use.
+            '';
+            defaultText = lib.literalMD ''a build using the pinned nix and nixpkgs of the `dwarffs` flake'';
+            default = self.defaultPackage.${pkgs.stdenv.hostPlatform.system};
+          };
+        };
+        config = {
+          systemd.packages = [ cfg.package ];
 
-          systemd.packages = [ pkgs.dwarffs ];
-
-          system.fsPackages = [ pkgs.dwarffs ];
+          system.fsPackages = [ cfg.package ];
 
           systemd.units."run-dwarffs.automount".wantedBy = [ "multi-user.target" ];
 
@@ -99,6 +109,6 @@
 
           users.groups.dwarffs = {};
         };
-
+      };
     };
 }

--- a/flake.nix
+++ b/flake.nix
@@ -10,13 +10,9 @@
       supportedSystems = [ "x86_64-linux" "i686-linux" "aarch64-linux" ];
       forAllSystems = f: nixpkgs.lib.genAttrs supportedSystems (system: f system);
       version = "0.1.${nixpkgs.lib.substring 0 8 self.lastModifiedDate}.${self.shortRev or "dirty"}";
-    in
 
-    {
-
-      overlay = final: prev: {
-
-        dwarffs = with final; let nix = final.nix; in stdenv.mkDerivation {
+      packageFunction = { stdenv, fuse, nix, nlohmann_json, boost }:
+        stdenv.mkDerivation {
           pname = "dwarffs";
           inherit version;
 
@@ -38,6 +34,12 @@
             '';
         };
 
+    in
+
+    {
+
+      overlay = final: prev: {
+        dwarffs = final.callPackage packageFunction {};
       };
 
       defaultPackage = forAllSystems (system: (import nixpkgs {


### PR DESCRIPTION
The Nix C++ interface is not stable, so dwarffs needs regular updates to stay compatible.
However, that's generally not worth the effort, as I don't think it uses any particularly critical or fast changing components, so let's make sure that it always builds by pinning `nix`.
TODO: confirm my assumption; make sure an outdated Nix is not hazardous.