### PR TITLE
dwarffs.cc: port to nix-2.25 (`ignoreException` rename)

### DIFF
--- a/dwarffs.cc
+++ b/dwarffs.cc
@@ -326,7 +326,7 @@ static int dwarffs_getattr(const char * path_, struct stat * stbuf)
         return res;
 
     } catch (std::exception & e) {
-        ignoreException();
+        ignoreExceptionExceptInterrupt();
         return -EIO;
     }
 }
@@ -375,7 +375,7 @@ static int dwarffs_open(const char * path_, struct fuse_file_info * fi)
         return 0;
 
     } catch (std::exception & e) {
-        ignoreException();
+        ignoreExceptionExceptInterrupt();
         return -EIO;
     }
 }
@@ -417,7 +417,7 @@ static int dwarffs_read(const char * path_, char * buf, size_t size, off_t offse
             return -ENOENT;
 
     } catch (std::exception & e) {
-        ignoreException();
+        ignoreExceptionExceptInterrupt();
         return -EIO;
     }
 }

--- a/flake.lock
+++ b/flake.lock
@@ -96,16 +96,16 @@
         "nixpkgs-regression": "nixpkgs-regression"
       },
       "locked": {
-        "lastModified": 1727305479,
-        "narHash": "sha256-YPJA0stZucs13Y2DQr3JIL6JfakP//LDbYXNhic/rKk=",
-        "rev": "618a0cc9875628171663c9bc3829ed3755a458ed",
-        "revCount": 18153,
+        "lastModified": 1731528268,
+        "narHash": "sha256-MZNpb4awWHXU+kGmH58VUB7M9l6UVo33riuQLTbMh4E=",
+        "rev": "f87f87120a86bc9de289be497cf1a5520acb23ae",
+        "revCount": 18707,
         "type": "tarball",
-        "url": "https://api.flakehub.com/f/pinned/NixOS/nix/2.24.8/01922bf0-4d5b-7753-b262-2497ef4593e8/source.tar.gz"
+        "url": "https://api.flakehub.com/f/pinned/NixOS/nix/2.25.2/01932a40-abae-7e35-86e4-6b8e7e4a3bfc/source.tar.gz"
       },
       "original": {
         "type": "tarball",
-        "url": "https://flakehub.com/f/NixOS/nix/2.20.tar.gz"
+        "url": "https://flakehub.com/f/NixOS/nix/2.25.tar.gz"
       }
     },
     "nixpkgs": {

--- a/flake.nix
+++ b/flake.nix
@@ -1,7 +1,7 @@
 {
   description = "A filesystem that fetches DWARF debug info from the Internet on demand";
 
-  inputs.nix.url = "https://flakehub.com/f/NixOS/nix/2.20.tar.gz";
+  inputs.nix.url = "https://flakehub.com/f/NixOS/nix/2.25.tar.gz";
   inputs.nixpkgs.follows = "nix/nixpkgs";
 
   outputs = { self, nix, nixpkgs }:


### PR DESCRIPTION
Without the change the build fails against latest `nix` as:

```
dwarffs> g++ -c -g -std=c++20 -Wall -Os dwarffs.cc -o dwarffs.o
dwarffs> dwarffs.cc: In function 'int dwarffs_getattr(const char*, stat*)':
dwarffs> dwarffs.cc:329:9: error: 'ignoreException' was not declared in this scope
dwarffs>   329 |         ignoreException();
dwarffs>       |         ^~~~~~~~~~~~~~~
dwarffs> dwarffs.cc: In function 'int dwarffs_open(const char*, fuse_file_info*)':
dwarffs> dwarffs.cc:378:9: error: 'ignoreException' was not declared in this scope
dwarffs>   378 |         ignoreException();
dwarffs>       |         ^~~~~~~~~~~~~~~
dwarffs> dwarffs.cc: In function 'int dwarffs_read(const char*, char*, size_t, off_t, fuse_file_info*)':
dwarffs> dwarffs.cc:420:9: error: 'ignoreException' was not declared in this scope
dwarffs>   420 |         ignoreException();
dwarffs>       |         ^~~~~~~~~~~~~~~
```