### PR TITLE
Fix build against Nix 2.28

### DIFF
--- a/dwarffs.cc
+++ b/dwarffs.cc
@@ -2,16 +2,16 @@
 #include <cstring>
 #include <regex>
 
-#include "util.hh"
-#include "logging.hh"
-#include "shared.hh"
-#include "filetransfer.hh"
-#include "archive.hh"
-#include "compression.hh"
-#include "nar-accessor.hh"
-#include "sync.hh"
-#include "environment-variables.hh"
-#include "users.hh"
+#include "util/util.hh"
+#include "util/logging.hh"
+#include "main/shared.hh"
+#include "store/filetransfer.hh"
+#include "util/archive.hh"
+#include "util/compression.hh"
+#include "store/nar-accessor.hh"
+#include "util/sync.hh"
+#include "util/environment-variables.hh"
+#include "util/users.hh"
 
 #include <sys/types.h>
 #include <sys/stat.h>

--- a/flake.lock
+++ b/flake.lock
@@ -68,58 +68,40 @@
         "type": "github"
       }
     },
-    "libgit2": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1715853528,
-        "narHash": "sha256-J2rCxTecyLbbDdsyBWn9w7r3pbKRMkI9E7RvRgAqBdY=",
-        "owner": "libgit2",
-        "repo": "libgit2",
-        "rev": "36f7e21ad757a3dacc58cf7944329da6bc1d6e96",
-        "type": "github"
-      },
-      "original": {
-        "owner": "libgit2",
-        "ref": "v1.8.1",
-        "repo": "libgit2",
-        "type": "github"
-      }
-    },
     "nix": {
       "inputs": {
         "flake-compat": "flake-compat",
         "flake-parts": "flake-parts",
         "git-hooks-nix": "git-hooks-nix",
-        "libgit2": "libgit2",
         "nixpkgs": "nixpkgs",
         "nixpkgs-23-11": "nixpkgs-23-11",
         "nixpkgs-regression": "nixpkgs-regression"
       },
       "locked": {
-        "lastModified": 1731528268,
-        "narHash": "sha256-MZNpb4awWHXU+kGmH58VUB7M9l6UVo33riuQLTbMh4E=",
-        "rev": "f87f87120a86bc9de289be497cf1a5520acb23ae",
-        "revCount": 18707,
+        "lastModified": 1758140738,
+        "narHash": "sha256-NLGXPLjENLeKVOg3OZgHXZ+1x6sPIKq9FHH8pxbCrDI=",
+        "rev": "fdea16241777b4a827d99436608b961960198785",
+        "revCount": 20777,
         "type": "tarball",
-        "url": "https://api.flakehub.com/f/pinned/NixOS/nix/2.25.2/01932a40-abae-7e35-86e4-6b8e7e4a3bfc/source.tar.gz"
+        "url": "https://api.flakehub.com/f/pinned/NixOS/nix/2.31.2/01995ca0-2a89-7c26-b708-8f2806b17291/source.tar.gz"
       },
       "original": {
         "type": "tarball",
-        "url": "https://flakehub.com/f/NixOS/nix/2.25.tar.gz"
+        "url": "https://flakehub.com/f/NixOS/nix/2.28.tar.gz"
       }
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1723688146,
-        "narHash": "sha256-sqLwJcHYeWLOeP/XoLwAtYjr01TISlkOfz+NG82pbdg=",
+        "lastModified": 1758216857,
+        "narHash": "sha256-h1BW2y7CY4LI9w61R02wPaOYfmYo82FyRqHIwukQ6SY=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "c3d4ac725177c030b1e289015989da2ad9d56af0",
+        "rev": "d2ed99647a4b195f0bcc440f76edfa10aeb3b743",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixos-24.05",
+        "ref": "nixos-25.05-small",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -1,7 +1,7 @@
 {
   description = "A filesystem that fetches DWARF debug info from the Internet on demand";
 
-  inputs.nix.url = "https://flakehub.com/f/NixOS/nix/2.25.tar.gz";
+  inputs.nix.url = "https://flakehub.com/f/NixOS/nix/2.28.tar.gz";
   inputs.nixpkgs.follows = "nix/nixpkgs";
 
   outputs = { self, nix, nixpkgs }:
@@ -22,7 +22,7 @@
 
           buildInputs = [ fuse nix nlohmann_json boost ];
 
-          NIX_CFLAGS_COMPILE = "-I ${nix.dev}/include/nix -include ${nix.dev}/include/nix/config.h -D_FILE_OFFSET_BITS=64 -DVERSION=\"${version}\"";
+          NIX_CFLAGS_COMPILE = "-I ${nix.dev}/include/nix -D_FILE_OFFSET_BITS=64 -DVERSION=\"${version}\"";
 
           src = self;
 


### PR DESCRIPTION
Not quite sure when those headers changed, but it seems to work fine. The `config.h` file no longer exists, but none of the `define`s there were used apparently.

Fixes #32 